### PR TITLE
Release 1.1.1: Ambiguous Constructor Call Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2024-08-15
+
+## Fixed
+
+- The default constructor, generated for record types when marked as partial, now applies the fully qualified type when propagating the default value, thereby removing the potential for ambiguity with the projection constructor (#8).
+
 ## [1.1.0] - 2024-08-05
 
 ## Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.31.0.96804" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.32.0.97167" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Fluentify.Console.Tests/Class/SingleTests/WhenWithAgeIsCalled.cs
+++ b/src/Fluentify.Console.Tests/Class/SingleTests/WhenWithAgeIsCalled.cs
@@ -1,0 +1,40 @@
+﻿namespace Fluentify.Console.Class.SingleTests;
+
+public sealed class WhenWithAgeIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Single? subject = default;
+
+        // Act
+        Func<Single> act = () => subject!.WithAge(1);
+
+        // Assert
+        _ = act.Should().Throw<ArgumentNullException>()
+            .WithParameterName(nameof(subject));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void GivenAnAgeThenTheValueIsApplied(int age)
+    {
+        // Arrange
+        var original = new Single
+        {
+            Age = Random.Shared.Next(),
+        };
+
+        // Act
+        Single actual = original.WithAge(age);
+
+        // Assert
+        _ = actual.Should().NotBeSameAs(original);
+        _ = actual.Age.Should().Be(age);
+    }
+}

--- a/src/Fluentify.Console.Tests/Record/SingleTests/WhenWithAgeIsCalled.cs
+++ b/src/Fluentify.Console.Tests/Record/SingleTests/WhenWithAgeIsCalled.cs
@@ -1,0 +1,40 @@
+﻿namespace Fluentify.Console.Record.SingleTests;
+
+public sealed class WhenWithAgeIsCalled
+{
+    [Fact]
+    public void GivenNullSubjectThenArgumentNullExceptionIsThrown()
+    {
+        // Arrange
+        Single? subject = default;
+
+        // Act
+        Func<Single> act = () => subject!.WithAge(1);
+
+        // Assert
+        _ = act.Should().Throw<ArgumentNullException>()
+            .WithParameterName(nameof(subject));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void GivenAnAgeThenTheValueIsApplied(int age)
+    {
+        // Arrange
+        var original = new Single
+        {
+            Age = Random.Shared.Next(),
+        };
+
+        // Act
+        Single actual = original.WithAge(age);
+
+        // Assert
+        _ = actual.Should().NotBeSameAs(original);
+        _ = actual.Age.Should().Be(age);
+    }
+}

--- a/src/Fluentify.Console/Class/CrossReferenced.cs
+++ b/src/Fluentify.Console/Class/CrossReferenced.cs
@@ -7,7 +7,7 @@
 internal sealed class CrossReferenced
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -15,7 +15,7 @@ internal sealed class CrossReferenced
     public required string Description { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/GlobalClass.cs
+++ b/src/Fluentify.Console/Class/GlobalClass.cs
@@ -1,7 +1,5 @@
-﻿#pragma warning disable SA1200 // Using directives should be placed correctly
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Fluentify;
-#pragma warning restore SA1200 // Using directives should be placed correctly
 
 /// <summary>
 /// A class that demonstrates the libraries use without generics.
@@ -11,7 +9,7 @@ using Fluentify;
 internal sealed class GlobalClass
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -19,7 +17,7 @@ internal sealed class GlobalClass
     public int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -27,7 +25,7 @@ internal sealed class GlobalClass
     public string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/MultipleGenerics.cs
+++ b/src/Fluentify.Console/Class/MultipleGenerics.cs
@@ -15,7 +15,7 @@ internal sealed class MultipleGenerics<T1, T2, T3>
     where T3 : IEnumerable<string>
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -23,7 +23,7 @@ internal sealed class MultipleGenerics<T1, T2, T3>
     public required T1? Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -31,7 +31,7 @@ internal sealed class MultipleGenerics<T1, T2, T3>
     public required T2? Name { get; init; }
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/Simple.cs
+++ b/src/Fluentify.Console/Class/Simple.cs
@@ -7,7 +7,7 @@
 internal sealed class Simple
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -15,7 +15,7 @@ internal sealed class Simple
     public int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -23,7 +23,7 @@ internal sealed class Simple
     public string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/SimpleWithArray.cs
+++ b/src/Fluentify.Console/Class/SimpleWithArray.cs
@@ -7,7 +7,7 @@
 internal sealed class SimpleWithArray
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -15,7 +15,7 @@ internal sealed class SimpleWithArray
     public required int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -23,7 +23,7 @@ internal sealed class SimpleWithArray
     public required string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/SimpleWithBoolean.cs
+++ b/src/Fluentify.Console/Class/SimpleWithBoolean.cs
@@ -7,7 +7,7 @@
 internal sealed class SimpleWithBoolean
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -15,7 +15,7 @@ internal sealed class SimpleWithBoolean
     public int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -23,7 +23,7 @@ internal sealed class SimpleWithBoolean
     public bool? IsRetired { get; init; }
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/SimpleWithCollection.cs
+++ b/src/Fluentify.Console/Class/SimpleWithCollection.cs
@@ -7,7 +7,7 @@
 internal sealed class SimpleWithCollection
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -15,7 +15,7 @@ internal sealed class SimpleWithCollection
     public required int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -23,7 +23,7 @@ internal sealed class SimpleWithCollection
     public required string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/SimpleWithEnumerables.cs
+++ b/src/Fluentify.Console/Class/SimpleWithEnumerables.cs
@@ -7,7 +7,7 @@
 internal sealed class SimpleWithEnumerables
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -15,7 +15,7 @@ internal sealed class SimpleWithEnumerables
     public required int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -23,7 +23,7 @@ internal sealed class SimpleWithEnumerables
     public required string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.
@@ -31,7 +31,7 @@ internal sealed class SimpleWithEnumerables
     public required IEnumerable<object> Attributes { get; init; }
 
     /// <summary>
-    /// Gets or sets the fourth property to be subject to the extension generator.
+    /// Gets the fourth property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The fourth property to be subject to the extension generator.
@@ -39,7 +39,7 @@ internal sealed class SimpleWithEnumerables
     public required IReadOnlyCollection<int> Numbers { get; init; }
 
     /// <summary>
-    /// Gets or sets the fifth property to be subject to the extension generator.
+    /// Gets the fifth property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The fifth property to be subject to the extension generator.

--- a/src/Fluentify.Console/Class/Single.cs
+++ b/src/Fluentify.Console/Class/Single.cs
@@ -1,0 +1,16 @@
+﻿namespace Fluentify.Console.Class;
+
+/// <summary>
+/// A class that demonstrates the libraries use on a type with just one property.
+/// </summary>
+[Fluentify]
+internal sealed class Single
+{
+    /// <summary>
+    /// Gets the first property to be subject to the extension generator.
+    /// </summary>
+    /// <value>
+    /// The first property to be subject to the extension generator.
+    /// </value>
+    public int Age { get; init; }
+}

--- a/src/Fluentify.Console/Class/SingleGeneric.cs
+++ b/src/Fluentify.Console/Class/SingleGeneric.cs
@@ -11,7 +11,7 @@ internal sealed class SingleGeneric<T>
     where T : IEnumerable
 {
     /// <summary>
-    /// Gets or sets the first property to be subject to the extension generator.
+    /// Gets the first property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The first property to be subject to the extension generator.
@@ -19,7 +19,7 @@ internal sealed class SingleGeneric<T>
     public required int Age { get; init; }
 
     /// <summary>
-    /// Gets or sets the second property to be subject to the extension generator.
+    /// Gets the second property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The second property to be subject to the extension generator.
@@ -27,7 +27,7 @@ internal sealed class SingleGeneric<T>
     public required string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the third property to be subject to the extension generator.
+    /// Gets the third property to be subject to the extension generator.
     /// </summary>
     /// <value>
     /// The third property to be subject to the extension generator.

--- a/src/Fluentify.Console/Record/Single.cs
+++ b/src/Fluentify.Console/Record/Single.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluentify.Console.Record;
+
+/// <summary>
+/// A record that demonstrates the libraries use on a type with just one property.
+/// </summary>
+/// <param name="Age">The first property to be subject to the extension generator.</param>
+[Fluentify]
+internal sealed partial record Single(int Age);

--- a/src/Fluentify.Tests/Model/PropertyTests/WhenEqualityIsChecked.cs
+++ b/src/Fluentify.Tests/Model/PropertyTests/WhenEqualityIsChecked.cs
@@ -14,6 +14,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -27,6 +28,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -52,6 +54,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -65,6 +68,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Private,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -90,6 +94,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor1",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -103,6 +108,47 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor2",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
+            Name = "PropertyName",
+        };
+
+        // Act
+        bool areEqual = AreEqual(instance1, instance2);
+
+        // Assert
+        _ = areEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GivenDifferentIsIgnoredThenTheyAreNotEqual()
+    {
+        // Arrange
+        var instance1 = new Property
+        {
+            Accessibility = Accessibility.Public,
+            Descriptor = "descriptor",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
+            Name = "PropertyName",
+        };
+        var instance2 = new Property
+        {
+            Accessibility = Accessibility.Public,
+            Descriptor = "descriptor",
+            IsIgnored = false,
             Kind = new()
             {
                 Type = new()
@@ -128,6 +174,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -141,6 +188,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -166,6 +214,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -179,6 +228,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -204,6 +254,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -243,6 +294,7 @@ public abstract class WhenEqualityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()

--- a/src/Fluentify.Tests/Model/PropertyTests/WhenInequalityIsChecked.cs
+++ b/src/Fluentify.Tests/Model/PropertyTests/WhenInequalityIsChecked.cs
@@ -14,6 +14,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -27,6 +28,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -52,6 +54,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -65,6 +68,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Private,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -90,6 +94,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor1",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -103,6 +108,47 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor2",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
+            Name = "PropertyName",
+        };
+
+        // Act
+        bool areNotEqual = AreNotEqual(instance1, instance2);
+
+        // Assert
+        _ = areNotEqual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GivenDifferentIsIgnoredThenTheyAreNotEqual()
+    {
+        // Arrange
+        var instance1 = new Property
+        {
+            Accessibility = Accessibility.Public,
+            Descriptor = "descriptor",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
+            Name = "PropertyName",
+        };
+        var instance2 = new Property
+        {
+            Accessibility = Accessibility.Public,
+            Descriptor = "descriptor",
+            IsIgnored = false,
             Kind = new()
             {
                 Type = new()
@@ -128,6 +174,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -141,6 +188,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -166,6 +214,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -179,6 +228,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -204,6 +254,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()
@@ -243,6 +294,7 @@ public abstract class WhenInequalityIsChecked
         {
             Accessibility = Accessibility.Public,
             Descriptor = "descriptor",
+            IsIgnored = true,
             Kind = new()
             {
                 Type = new()

--- a/src/Fluentify.Tests/Semantics/INamedTypeSymbolExtensionsTests/WhenGetPropertiesIsCalled.cs
+++ b/src/Fluentify.Tests/Semantics/INamedTypeSymbolExtensionsTests/WhenGetPropertiesIsCalled.cs
@@ -266,6 +266,14 @@ public sealed class WhenGetPropertiesIsCalled
         var name = new Property
         {
             Descriptor = "WithName",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
             Name = "Name",
         };
 
@@ -283,6 +291,14 @@ public sealed class WhenGetPropertiesIsCalled
         var age = new Property
         {
             Descriptor = "WithAge",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "int",
+                },
+            },
             Name = "Age",
         };
 
@@ -291,6 +307,14 @@ public sealed class WhenGetPropertiesIsCalled
         var name = new Property
         {
             Descriptor = "WithName",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
             Name = "Name",
         };
 
@@ -349,7 +373,25 @@ public sealed class WhenGetPropertiesIsCalled
     [MemberData(nameof(GivenDescriptorOnIgnoredThenTheExpectedPropertiesAreReturnedData))]
     public void GivenDescriptorOnIgnoredThenTheExpectedPropertiesAreReturned(Compilation compilation, Definition definition, bool isNullable)
     {
-        GivenOneOfThreeIgnoredThenTheExpectedPropertiesAreReturned(compilation, definition, isNullable);
+        // Arrange
+        var name = new Property
+        {
+            Descriptor = "WithName",
+            IsIgnored = true,
+            Kind = new()
+            {
+                Type = new()
+                {
+                    Name = "string",
+                },
+            },
+            Name = "Name",
+        };
+
+        Property attributes = GetAttributes(isNullable);
+
+        // Act & Assert
+        ActAndAssert(compilation, definition, age, attributes, name);
     }
 
     private static void ActAndAssert(Compilation compilation, Definition definition, params Property[] expected)

--- a/src/Fluentify.Tests/Snippets/Classes.Single.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Single.cs
@@ -1,0 +1,64 @@
+﻿namespace Fluentify.Snippets;
+
+using System.Diagnostics.CodeAnalysis;
+
+public static partial class Classes
+{
+    public const string SingleContent = """
+        namespace Fluentify.Classes.Testing
+        {
+            using System.Collections.Generic;
+
+            [Fluentify]
+            public sealed class Single
+            {
+                public int Age { get; set; }
+            }
+        }
+        """;
+
+    [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "The name is appropriate.")]
+    public static readonly Declared Single;
+
+    public static readonly Generated SingleWithAgeExtensions = new(
+        SingleWithAgeExtensionsContent,
+        typeof(ClassGenerator),
+        "Fluentify.Classes.Testing.SingleExtensions.WithAge");
+
+    private const string SingleWithAgeExtensionsContent = """
+        #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        #nullable enable
+        #endif
+        
+        #pragma warning disable CS8625
+
+        namespace Fluentify.Classes.Testing
+        {
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using Fluentify.Internal;
+
+            public static partial class SingleExtensions
+            {
+                public static global::Fluentify.Classes.Testing.Single WithAge(
+                    this global::Fluentify.Classes.Testing.Single subject,
+                    int value)
+                {
+                    subject.ThrowIfNull("subject");
+
+                    return new global::Fluentify.Classes.Testing.Single
+                    {
+                        Age = value,
+                    };
+                }
+            }
+        }
+
+        #pragma warning restore CS8625
+        
+        #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        #nullable restore
+        #endif
+        """;
+}

--- a/src/Fluentify.Tests/Snippets/Classes.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.cs
@@ -78,6 +78,8 @@ public static partial class Classes
             SimpleWithNameExtensions,
             SimpleWithAttributesExtensions);
 
+        Single = new(SingleContent, nameof(Single), SingleWithAgeExtensions);
+
         SingleGeneric = new(
             SingleGenericContent,
             nameof(SingleGeneric),

--- a/src/Fluentify.Tests/Snippets/Records.AllThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.AllThreeIgnored.cs
@@ -35,7 +35,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public AllThreeIgnored()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.Boolean.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Boolean.cs
@@ -48,7 +48,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public Boolean()
-                    : this(default, default, default)
+                    : this(default(int), default(bool), default(string))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.CrossReferenced.cs
+++ b/src/Fluentify.Tests/Snippets/Records.CrossReferenced.cs
@@ -43,7 +43,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public CrossReferenced()
-                    : this(default, default)
+                    : this(default(string), default(global::Fluentify.Records.Testing.Simple))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
@@ -45,7 +45,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public DescriptorOnIgnored()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
@@ -50,7 +50,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public DescriptorOnOptional()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
@@ -50,7 +50,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public DescriptorOnRequired()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Global.cs
@@ -46,7 +46,7 @@ public static partial class Records
             [SetsRequiredMembers]
             #endif
             public Global()
-                : this(default, default, default)
+                : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
             {
             }
 

--- a/src/Fluentify.Tests/Snippets/Records.MultipleGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.MultipleGenerics.cs
@@ -53,7 +53,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public MultipleGenerics()
-                    : this(default, default, default)
+                    : this(default(T1?), default(T2?), default(T3))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
@@ -45,7 +45,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public OneOfThreeIgnored()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Simple.cs
@@ -50,7 +50,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public Simple()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.Single.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Single.cs
@@ -1,0 +1,88 @@
+﻿namespace Fluentify.Snippets;
+
+using System.Diagnostics.CodeAnalysis;
+
+public static partial class Records
+{
+    public const string SingleContent = """
+        namespace Fluentify.Records.Testing
+        {
+            using System.Collections.Generic;
+
+            [Fluentify]
+            public sealed partial record Single(int Age);
+        }
+        """;
+
+    [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "The name is appropriate.")]
+    public static readonly Declared Single;
+
+    public static readonly Generated SingleConstructor = new(
+        SingleConstructorContent,
+        typeof(RecordGenerator),
+        "Fluentify.Records.Testing.Single.ctor");
+
+    public static readonly Generated SingleWithAgeExtensions = new(
+        SingleWithAgeExtensionsContent,
+        typeof(RecordGenerator),
+        "Fluentify.Records.Testing.SingleExtensions.WithAge");
+
+    private const string SingleConstructorContent = """
+        #nullable enable
+        #pragma warning disable CS8625
+
+        namespace Fluentify.Records.Testing
+        {
+            using System.Diagnostics.CodeAnalysis;
+
+            partial record Single
+            {
+                #pragma warning disable CS8604
+
+                #if NET7_0_OR_GREATER
+                [SetsRequiredMembers]
+                #endif
+                public Single()
+                    : this(default(int))
+                {
+                }
+
+                #pragma warning restore CS8604
+            }
+        }
+
+        #pragma warning restore CS8625
+        #nullable restore
+        """;
+
+    private const string SingleWithAgeExtensionsContent = """
+        #nullable enable
+        #pragma warning disable CS8625
+
+        namespace Fluentify.Records.Testing
+        {
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using Fluentify.Internal;
+
+            public static partial class SingleExtensions
+            {
+                public static global::Fluentify.Records.Testing.Single WithAge(
+                    this global::Fluentify.Records.Testing.Single subject,
+                    int value)
+                {
+                    subject.ThrowIfNull("subject");
+
+                    return subject with
+                    {
+                        Age = value,
+                    };
+                }
+            }
+        }
+
+        #pragma warning restore CS8625
+        #nullable restore
+        """;
+}

--- a/src/Fluentify.Tests/Snippets/Records.SingleGeneric.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SingleGeneric.cs
@@ -51,7 +51,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public SingleGeneric()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(T?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
@@ -40,7 +40,7 @@ public static partial class Records
                 [SetsRequiredMembers]
                 #endif
                 public TwoOfThreeIgnored()
-                    : this(default, default, default)
+                    : this(default(int), default(string), default(global::System.Collections.Generic.IReadOnlyList<object>?))
                 {
                 }
 

--- a/src/Fluentify.Tests/Snippets/Records.cs
+++ b/src/Fluentify.Tests/Snippets/Records.cs
@@ -88,6 +88,8 @@ public static partial class Records
             SimpleWithNameExtensions,
             SimpleWithAttributesExtensions);
 
+        Single = new(SingleContent, nameof(Single), SingleConstructor, SingleWithAgeExtensions);
+
         SingleGeneric = new(
             SingleGenericContent,
             nameof(SingleGeneric),

--- a/src/Fluentify.Tests/Source/SubjectExtensionsTests/WhenGetConstructorIsCalled.cs
+++ b/src/Fluentify.Tests/Source/SubjectExtensionsTests/WhenGetConstructorIsCalled.cs
@@ -55,7 +55,7 @@ public sealed class WhenGetConstructorIsCalled
                 [SetsRequiredMembers]
                 #endif
                 public TestClass()
-                    : this(default, default)
+                    : this(default(string), default(int))
                 {
                 }
 

--- a/src/Fluentify/Analyzer.cs
+++ b/src/Fluentify/Analyzer.cs
@@ -50,6 +50,23 @@ public abstract class Analyzer<TSyntax>
     }
 
     /// <summary>
+    /// Raises a <see cref="Diagnostic"/> instance within the specified <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">
+    /// Context for a syntax node action. A syntax node action can use a Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext
+    /// to report Microsoft.CodeAnalysis.Diagnostics for a Microsoft.CodeAnalysis.SyntaxNode.
+    /// </param>
+    /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
+    /// <param name="location">An location of the diagnostic.</param>
+    /// <param name="arguments">Arguments to the message of the diagnostic.</param>
+    protected static void Raise(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, Location location, params object[] arguments)
+    {
+        var diagnostic = Diagnostic.Create(descriptor, location, arguments);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    /// <summary>
     /// Performs analysis upon the <paramref name="syntax"/>, which is deemed to have matched the
     /// <typeparamref name="TSyntax"/> and <see cref="kind"/> values.
     /// </summary>
@@ -61,23 +78,6 @@ public abstract class Analyzer<TSyntax>
     /// The <typeparamref name="TSyntax"/> matched within the <paramref name="context"/> to which the analysis is to be applied.
     /// </param>
     protected abstract void AnalyzeNode(SyntaxNodeAnalysisContext context, TSyntax syntax);
-
-    /// <summary>
-    /// Raises a <see cref="Diagnostic"/> instance within the specified <paramref name="context"/>.
-    /// </summary>
-    /// <param name="context">
-    /// Context for a syntax node action. A syntax node action can use a Microsoft.CodeAnalysis.Diagnostics.SyntaxNodeAnalysisContext
-    /// to report Microsoft.CodeAnalysis.Diagnostics for a Microsoft.CodeAnalysis.SyntaxNode.
-    /// </param>
-    /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
-    /// <param name="location">An location of the diagnostic.</param>
-    /// <param name="arguments">Arguments to the message of the diagnostic.</param>
-    protected void Raise(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, Location location, params object[] arguments)
-    {
-        var diagnostic = Diagnostic.Create(descriptor, location, arguments);
-
-        context.ReportDiagnostic(diagnostic);
-    }
 
     private void AnalyzeNode(SyntaxNodeAnalysisContext context)
     {

--- a/src/Fluentify/Model/Property.cs
+++ b/src/Fluentify/Model/Property.cs
@@ -35,12 +35,12 @@ internal sealed class Property
     public Kind Kind { get; set; } = Kind.Unspecified;
 
     /// <summary>
-    /// Gets a value indicating whether or not the property has been annotated with the Ignore attribute.
+    /// Gets or sets a value indicating whether or not the property has been annotated with the Ignore attribute.
     /// </summary>
     /// <value>
     /// A value indicating whether or not the property has been annotated with the Ignore attribute.
     /// </value>
-    public bool IsIgnored => Kind == Kind.Unspecified;
+    public bool IsIgnored { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the property as defined within the subject.
@@ -55,6 +55,7 @@ internal sealed class Property
     {
         yield return Accessibility;
         yield return Descriptor;
+        yield return IsIgnored;
         yield return Kind;
         yield return Name;
     }

--- a/src/Fluentify/Semantics/INamedTypeSymbolExtensions.GetProperties.cs
+++ b/src/Fluentify/Semantics/INamedTypeSymbolExtensions.GetProperties.cs
@@ -28,13 +28,13 @@ internal static partial class INamedTypeSymbolExtensions
 
     private static Property Map(this IPropertySymbol property, Compilation compilation, CancellationToken cancellationToken)
     {
+        Kind kind = property.GetKind(compilation, cancellationToken);
+        bool isIgnored = property.HasIgnore();
         string? descriptor = default;
-        Kind kind = Kind.Unspecified;
 
-        if (!property.HasIgnore())
+        if (!isIgnored)
         {
             descriptor = property.GetDescriptor();
-            kind = property.GetKind(compilation, cancellationToken);
         }
 
         descriptor ??= kind.Type.IsBoolean
@@ -45,8 +45,9 @@ internal static partial class INamedTypeSymbolExtensions
         {
             Accessibility = property.DeclaredAccessibility,
             Descriptor = descriptor,
-            Name = property.Name,
+            IsIgnored = isIgnored,
             Kind = kind,
+            Name = property.Name,
         };
     }
 }

--- a/src/Fluentify/Source/SubjectExtensions.GetConstructor.cs
+++ b/src/Fluentify/Source/SubjectExtensions.GetConstructor.cs
@@ -16,7 +16,7 @@ internal static partial class SubjectExtensions
     /// </returns>
     public static string GetConstructor(this Subject subject)
     {
-        IEnumerable<string> initializers = subject.Properties.Select(_ => "default");
+        IEnumerable<string> initializers = subject.Properties.Select(property => $"default({property.Kind})");
         string parameters = string.Join(", ", initializers);
 
         return $$"""


### PR DESCRIPTION
## Fixed

- The default constructor, generated for record types when marked as partial, now applies the fully qualified type when propagating the default value, thereby removing the potential for ambiguity with the projection constructor (#8).