### PR TITLE
Adopt underscore-prefixed field names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -179,9 +179,9 @@ dotnet_naming_rule.private_constant_should_be_pascal_case.severity = error
 dotnet_naming_rule.private_constant_should_be_pascal_case.symbols = private_constant
 dotnet_naming_rule.private_constant_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.private_static_field_should_be_camel_case.severity = error
-dotnet_naming_rule.private_static_field_should_be_camel_case.symbols = private_static_field
-dotnet_naming_rule.private_static_field_should_be_camel_case.style = camel_case
+dotnet_naming_rule.private_fields_should_be_underscore_prefixed.severity = error
+dotnet_naming_rule.private_fields_should_be_underscore_prefixed.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_underscore_prefixed.style = underscore_prefix
 
 # Symbol specifications
 
@@ -197,9 +197,9 @@ dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, meth
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
 dotnet_naming_symbols.non_field_members.required_modifiers =
 
-dotnet_naming_symbols.private_static_field.applicable_kinds = field
-dotnet_naming_symbols.private_static_field.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_field.required_modifiers = static
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers =
 
 dotnet_naming_symbols.private_constant.applicable_kinds = field
 dotnet_naming_symbols.private_constant.applicable_accessibilities = private
@@ -221,6 +221,10 @@ dotnet_naming_style.camel_case.required_prefix =
 dotnet_naming_style.camel_case.required_suffix =
 dotnet_naming_style.camel_case.word_separator =
 dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_prefix.required_prefix = _
+dotnet_naming_style.underscore_prefix.required_suffix =
+dotnet_naming_style.underscore_prefix.word_separator =
+dotnet_naming_style.underscore_prefix.capitalization = camel_case
 dotnet_diagnostic.S1117.severity = none
 dotnet_diagnostic.SA1506.severity=silent
 dotnet_diagnostic.SA1500.severity=error
@@ -262,10 +266,10 @@ dotnet_diagnostic.SA1302.severity=error
 dotnet_diagnostic.SA1303.severity=error
 dotnet_diagnostic.SA1304.severity=error
 dotnet_diagnostic.SA1305.severity=error
-dotnet_diagnostic.SA1306.severity=error
+dotnet_diagnostic.SA1306.severity=none
 dotnet_diagnostic.SA1307.severity=error
 dotnet_diagnostic.SA1308.severity=error
-dotnet_diagnostic.SA1309.severity=error
+dotnet_diagnostic.SA1309.severity=none
 dotnet_diagnostic.SA1310.severity=error
 dotnet_diagnostic.SA1311.severity=silent
 dotnet_diagnostic.SA1312.severity=error
@@ -454,7 +458,7 @@ dotnet_diagnostic.CA2009.severity=warning
 dotnet_diagnostic.CA2011.severity=warning
 dotnet_diagnostic.CA2012.severity=warning
 dotnet_diagnostic.CA1700.severity=error
-dotnet_diagnostic.CA1707.severity=error
+dotnet_diagnostic.CA1707.severity=none
 dotnet_diagnostic.CA1708.severity=error
 dotnet_diagnostic.CA1710.severity=error
 dotnet_diagnostic.CA1711.severity=silent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Root Instructions for Codex
+
+This repository hosts **Fluentify**, a .NET source generator and analyzers solution.
+
+> **Note**
+> This file provides quick instructions for Codex. Human contributors should refer to the
+> [README](README.md) and [CONTRIBUTING guide](.github/CONTRIBUTING.md) for a fuller picture.
+
+## Build and Test
+
+- Use the .NET SDK **9.0**. The latest SDK can be found at [dotnet.microsoft.com](https://dotnet.microsoft.com/).
+- Restore packages with `dotnet restore`.
+- Run `dotnet test` to execute the test suite. This is the primary check before committing.
+- Tests are configured via `.runsettings` and use xUnit.
+
+## Coding Style
+
+The project enforces strong C# coding conventions through `.editorconfig`, [StyleCop Analyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers), and [SonarAnalyzer for C#](https://github.com/SonarSource/sonar-dotnet). Key points from the [Contributing guide](.github/CONTRIBUTING.md):
+
+- Prefer **file-scoped namespaces**.
+- Follow Microsoft naming guidelines (PascalCase for types and members, camelCase for locals/parameters, prefix interfaces with `I`).
+- Seal classes when extension is not intended.
+- Use discards (`_`) for unused values.
+- Organize extension methods so each file is named `{TypeName}Extensions.{MethodName}.cs`.
+- Use resource files for all user-facing strings with names `{TypeName}.Resources.{locale}.resx` and keys formatted as `{Context}{Subject}{Purpose}`.
+- Avoid `#region` pragmas.
+- Avoid abrieviations in names, except for well-known acronyms (e.g., `Http`, `Xml`).
+- Avoid single-letter names, even for loop variables.
+- Avoid qualified types, use `using` directives instead or an alias if necessary.
+- Use `var` for local variables when the type is clear from the right-hand side.
+- Use `nameof` for member names in exceptions and logging.
+- Use `string.Empty` instead of `""` for empty strings.
+
+### Unit Testing Conventions
+
+- Follow **Arrange-Act-Assert** structure.
+- Place tests for a class under a matching namespace `{Class Namespace}.{Class Name}Tests`.
+- Name test classes `When{MethodName}IsCalled` and test methods `Given{Condition}When{State}Then{Expectation}`. If no {State} is needed, use `Given{Condition}Then{Expectation}`. Do not use the MethodName in the test name, as all tests in the class relate to the same method and the class name identified the method name.
+- Use [`Shouldy`](https://docs.shouldly.org/) and `NSubstitute` for assertions and mocks.
+- Use constants for test data, especially for strings and numbers, to avoid magic values.
+
+## Project Structure
+
+- Production code resides in `src/Fluentify`.
+- Tests live in `src/Fluentify.Tests` and mirror the main project layout.
+- Documentation for analyzers is under `docs/rules`.
+
+## Pull Requests
+
+The [PR template](.github/pull_request_template.md) requires that you:
+
+- Follow the coding style.
+- Add or update tests when necessary.
+- Ensure tests pass locally.
+- Update `CHANGELOG.md` when consumer-facing changes occur.

--- a/Fluentify.sln
+++ b/Fluentify.sln
@@ -38,6 +38,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fluentify.Console.Tests", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{E9DE67A5-339C-4BA3-BD91-F9E0937B3BFF}"
 	ProjectSection(SolutionItems) = preProject
+		AGENTS.md = AGENTS.md
 		CHANGELOG.md = CHANGELOG.md
 		.github\CODE_OF_CONDUCT.md = .github\CODE_OF_CONDUCT.md
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md

--- a/analyzers/code.ruleset
+++ b/analyzers/code.ruleset
@@ -9,6 +9,9 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S1117" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1707" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA0002" Action="Error" />
@@ -100,7 +103,7 @@
     <Rule Id="SA1303" Action="Error" />
     <Rule Id="SA1304" Action="Error" />
     <Rule Id="SA1305" Action="Error" />
-    <Rule Id="SA1306" Action="Error" />
+    <Rule Id="SA1306" Action="None" />
     <Rule Id="SA1307" Action="Error" />
     <Rule Id="SA1308" Action="Error" />
     <Rule Id="SA1309" Action="None" />

--- a/analyzers/tests.ruleset
+++ b/analyzers/tests.ruleset
@@ -10,6 +10,9 @@
     <Rule Id="S1117" Action="None" />
     <Rule Id="S4144" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1707" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA0002" Action="Error" />
@@ -101,7 +104,7 @@
     <Rule Id="SA1303" Action="Error" />
     <Rule Id="SA1304" Action="Error" />
     <Rule Id="SA1305" Action="Error" />
-    <Rule Id="SA1306" Action="Error" />
+    <Rule Id="SA1306" Action="None" />
     <Rule Id="SA1307" Action="Error" />
     <Rule Id="SA1308" Action="Error" />
     <Rule Id="SA1309" Action="None" />

--- a/src/Fluentify.Tests/AnalyzerTests.cs
+++ b/src/Fluentify.Tests/AnalyzerTests.cs
@@ -12,28 +12,28 @@ public abstract class AnalyzerTests<TAnalyzer, TGenerator>
     where TAnalyzer : DiagnosticAnalyzer, new()
     where TGenerator : new()
 {
-    private readonly Type[] generators;
-    private readonly LanguageVersion languageVersion;
+    private readonly Type[] _generators;
+    private readonly LanguageVersion _languageVersion;
 
     protected AnalyzerTests(ReferenceAssemblies assemblies, LanguageVersion languageVersion, params Type[] generators)
     {
-        this.generators = generators.Length == 0
+        _generators = generators.Length == 0
             ? [typeof(FluentifyAttributeGenerator), typeof(TGenerator)]
             : generators;
 
-        this.languageVersion = languageVersion;
+        _languageVersion = languageVersion;
         ReferenceAssemblies = assemblies;
         TestBehaviors = TestBehaviors.SkipGeneratedSourcesCheck;
     }
 
     protected sealed override ParseOptions CreateParseOptions()
     {
-        return new CSharpParseOptions(languageVersion);
+        return new CSharpParseOptions(_languageVersion);
     }
 
     protected sealed override IEnumerable<Type> GetSourceGenerators()
     {
-        return generators;
+        return _generators;
     }
 
     protected Task ActAndAssertAsync()

--- a/src/Fluentify.Tests/ClassGeneratorTests/WhenExecuted.cs
+++ b/src/Fluentify.Tests/ClassGeneratorTests/WhenExecuted.cs
@@ -5,7 +5,7 @@ using Fluentify.Snippets;
 public sealed class WhenExecuted
     : GeneratorTests<ClassGenerator>
 {
-    private static readonly Type[] generators =
+    private static readonly Type[] _generators =
     [
         typeof(ClassGenerator),
         typeof(DescriptorAttributeGenerator),
@@ -15,7 +15,7 @@ public sealed class WhenExecuted
     ];
 
     public WhenExecuted()
-        : base(Classes.ReferenceAssemblies, Classes.LanguageVersion, generators)
+        : base(Classes.ReferenceAssemblies, Classes.LanguageVersion, _generators)
     {
     }
 

--- a/src/Fluentify.Tests/DescriptorAttributeAnalyzerTests/WhenExecuted.cs
+++ b/src/Fluentify.Tests/DescriptorAttributeAnalyzerTests/WhenExecuted.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 public abstract partial class WhenExecuted
     : AnalyzerTests<DescriptorAttributeAnalyzer, DescriptorAttributeGenerator>
 {
-    private static readonly Type[] generators =
+    private static readonly Type[] _generators =
     [
         typeof(DescriptorAttributeGenerator),
         typeof(FluentifyAttributeGenerator),
@@ -17,7 +17,7 @@ public abstract partial class WhenExecuted
     ];
 
     protected WhenExecuted(ReferenceAssemblies assemblies, LanguageVersion languageVersion)
-        : base(assemblies, languageVersion, generators)
+        : base(assemblies, languageVersion, _generators)
     {
     }
 

--- a/src/Fluentify.Tests/GeneratorTests.cs
+++ b/src/Fluentify.Tests/GeneratorTests.cs
@@ -9,27 +9,27 @@ public abstract class GeneratorTests<TGenerator>
     : CSharpSourceGeneratorTest<TGenerator, DefaultVerifier>
     where TGenerator : new()
 {
-    private readonly Type[] generators;
-    private readonly LanguageVersion languageVersion;
+    private readonly Type[] _generators;
+    private readonly LanguageVersion _languageVersion;
 
     protected GeneratorTests(ReferenceAssemblies assemblies, LanguageVersion languageVersion, params Type[] generators)
     {
-        this.generators = generators.Length == 0
+        _generators = generators.Length == 0
             ? [typeof(TGenerator)]
             : generators;
 
-        this.languageVersion = languageVersion;
+        _languageVersion = languageVersion;
         ReferenceAssemblies = assemblies;
     }
 
     protected sealed override ParseOptions CreateParseOptions()
     {
-        return new CSharpParseOptions(languageVersion);
+        return new CSharpParseOptions(_languageVersion);
     }
 
     protected sealed override IEnumerable<Type> GetSourceGenerators()
     {
-        return generators;
+        return _generators;
     }
 
     protected Task ActAndAssertAsync()

--- a/src/Fluentify.Tests/RecordGeneratorTests/WhenExecuted.cs
+++ b/src/Fluentify.Tests/RecordGeneratorTests/WhenExecuted.cs
@@ -5,7 +5,7 @@ using Fluentify.Snippets;
 public sealed class WhenExecuted
     : GeneratorTests<RecordGenerator>
 {
-    private static readonly Type[] generators =
+    private static readonly Type[] _generators =
     [
         typeof(DescriptorAttributeGenerator),
         typeof(FluentifyAttributeGenerator),
@@ -15,7 +15,7 @@ public sealed class WhenExecuted
     ];
 
     public WhenExecuted()
-        : base(Records.ReferenceAssemblies, Records.LanguageVersion, generators)
+        : base(Records.ReferenceAssemblies, Records.LanguageVersion, _generators)
     {
     }
 

--- a/src/Fluentify.Tests/Semantics/INamedTypeSymbolExtensionsTests/WhenGetPropertiesIsCalled.cs
+++ b/src/Fluentify.Tests/Semantics/INamedTypeSymbolExtensionsTests/WhenGetPropertiesIsCalled.cs
@@ -221,7 +221,7 @@ public sealed class WhenGetPropertiesIsCalled
         };
 
         // Act & Assert
-        ActAndAssert(compilation, definition, _age, attributes, _name);
+        ActAndAssert(compilation, definition, age, attributes, name);
     }
 
     [Theory]
@@ -255,7 +255,7 @@ public sealed class WhenGetPropertiesIsCalled
         };
 
         // Act & Assert
-        ActAndAssert(compilation, definition, _age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, _name);
     }
 
     [Theory]
@@ -280,7 +280,7 @@ public sealed class WhenGetPropertiesIsCalled
         Property attributes = GetAttributes(isNullable);
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, name);
     }
 
     [Theory]

--- a/src/Fluentify.Tests/Semantics/INamedTypeSymbolExtensionsTests/WhenGetPropertiesIsCalled.cs
+++ b/src/Fluentify.Tests/Semantics/INamedTypeSymbolExtensionsTests/WhenGetPropertiesIsCalled.cs
@@ -78,7 +78,7 @@ public sealed class WhenGetPropertiesIsCalled
         { Records.Instance.Compilation, Records.Instance.TwoOfThreeIgnored, true },
     };
 
-    private static readonly Property age = new()
+    private static readonly Property _age = new()
     {
         Descriptor = "WithAge",
         Kind = new()
@@ -91,7 +91,7 @@ public sealed class WhenGetPropertiesIsCalled
         Name = "Age",
     };
 
-    private static readonly Property name = new()
+    private static readonly Property _name = new()
     {
         Descriptor = "WithName",
         Kind = new()
@@ -123,7 +123,7 @@ public sealed class WhenGetPropertiesIsCalled
         };
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, isRetired, name);
+        ActAndAssert(compilation, definition, _age, isRetired, _name);
     }
 
     [Theory]
@@ -221,7 +221,7 @@ public sealed class WhenGetPropertiesIsCalled
         };
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, _name);
     }
 
     [Theory]
@@ -232,7 +232,7 @@ public sealed class WhenGetPropertiesIsCalled
         Property attributes = GetAttributes(isNullable);
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, _name);
     }
 
     [Theory]
@@ -255,7 +255,7 @@ public sealed class WhenGetPropertiesIsCalled
         };
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, name);
     }
 
     [Theory]
@@ -355,7 +355,7 @@ public sealed class WhenGetPropertiesIsCalled
         Property attributes = GetAttributes(isNullable);
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, age, attributes, _name);
     }
 
     [Theory]
@@ -366,7 +366,7 @@ public sealed class WhenGetPropertiesIsCalled
         Property attributes = GetAttributes(isNullable, descriptor: "AttributedWith");
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, _name);
     }
 
     [Theory]
@@ -391,7 +391,7 @@ public sealed class WhenGetPropertiesIsCalled
         Property attributes = GetAttributes(isNullable);
 
         // Act & Assert
-        ActAndAssert(compilation, definition, age, attributes, name);
+        ActAndAssert(compilation, definition, _age, attributes, name);
     }
 
     private static void ActAndAssert(Compilation compilation, Definition definition, params Property[] expected)

--- a/src/Fluentify/Analyzer.Resources.Designer.cs
+++ b/src/Fluentify/Analyzer.Resources.Designer.cs
@@ -24,9 +24,9 @@ namespace Fluentify {
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Analyzer_Resources {
         
-        private static global::System.Resources.ResourceManager resourceMan;
-        
-        private static global::System.Globalization.CultureInfo resourceCulture;
+        private static global::System.Resources.ResourceManager _resourceMan;
+
+        private static global::System.Globalization.CultureInfo _resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Analyzer_Resources() {
@@ -38,11 +38,11 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+                if (object.ReferenceEquals(_resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Fluentify.Analyzer.Resources", typeof(Analyzer_Resources).Assembly);
-                    resourceMan = temp;
+                    _resourceMan = temp;
                 }
-                return resourceMan;
+                return _resourceMan;
             }
         }
         
@@ -53,10 +53,10 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Globalization.CultureInfo Culture {
             get {
-                return resourceCulture;
+                return _resourceCulture;
             }
             set {
-                resourceCulture = value;
+                _resourceCulture = value;
             }
         }
         
@@ -65,7 +65,7 @@ namespace Fluentify {
         /// </summary>
         internal static string Description {
             get {
-                return ResourceManager.GetString("Description", resourceCulture);
+                return ResourceManager.GetString("Description", _resourceCulture);
             }
         }
         
@@ -74,7 +74,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MessageFormat {
             get {
-                return ResourceManager.GetString("MessageFormat", resourceCulture);
+                return ResourceManager.GetString("MessageFormat", _resourceCulture);
             }
         }
         
@@ -83,7 +83,7 @@ namespace Fluentify {
         /// </summary>
         internal static string Title {
             get {
-                return ResourceManager.GetString("Title", resourceCulture);
+                return ResourceManager.GetString("Title", _resourceCulture);
             }
         }
     }

--- a/src/Fluentify/Analyzer.cs
+++ b/src/Fluentify/Analyzer.cs
@@ -13,7 +13,7 @@ public abstract class Analyzer<TSyntax>
     where TSyntax : CSharpSyntaxNode
 {
     private const string Branch = "master";
-    private readonly SyntaxKind kind;
+    private readonly SyntaxKind _kind;
 
     /// <summary>
     /// Facilitates construction of an analyzer that matches for the specified <paramref name="kind"/>.
@@ -21,7 +21,7 @@ public abstract class Analyzer<TSyntax>
     /// <param name="kind">The type of syntax to match.</param>
     private protected Analyzer(SyntaxKind kind)
     {
-        this.kind = kind;
+        _kind = kind;
     }
 
     /// <inheritdoc/>
@@ -29,7 +29,7 @@ public abstract class Analyzer<TSyntax>
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterSyntaxNodeAction(AnalyzeNode, kind);
+        context.RegisterSyntaxNodeAction(AnalyzeNode, _kind);
     }
 
     /// <summary>

--- a/src/Fluentify/AttributeAnalyzer.Resources.Designer.cs
+++ b/src/Fluentify/AttributeAnalyzer.Resources.Designer.cs
@@ -24,9 +24,9 @@ namespace Fluentify {
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AttributeAnalyzer_Resources {
         
-        private static global::System.Resources.ResourceManager resourceMan;
-        
-        private static global::System.Globalization.CultureInfo resourceCulture;
+        private static global::System.Resources.ResourceManager _resourceMan;
+
+        private static global::System.Globalization.CultureInfo _resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal AttributeAnalyzer_Resources() {
@@ -38,11 +38,11 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+                if (object.ReferenceEquals(_resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Fluentify.AttributeAnalyzer.Resources", typeof(AttributeAnalyzer_Resources).Assembly);
-                    resourceMan = temp;
+                    _resourceMan = temp;
                 }
-                return resourceMan;
+                return _resourceMan;
             }
         }
         
@@ -53,10 +53,10 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Globalization.CultureInfo Culture {
             get {
-                return resourceCulture;
+                return _resourceCulture;
             }
             set {
-                resourceCulture = value;
+                _resourceCulture = value;
             }
         }
         
@@ -65,7 +65,7 @@ namespace Fluentify {
         /// </summary>
         internal static string Description {
             get {
-                return ResourceManager.GetString("Description", resourceCulture);
+                return ResourceManager.GetString("Description", _resourceCulture);
             }
         }
         
@@ -74,7 +74,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MessageFormat {
             get {
-                return ResourceManager.GetString("MessageFormat", resourceCulture);
+                return ResourceManager.GetString("MessageFormat", _resourceCulture);
             }
         }
         
@@ -83,7 +83,7 @@ namespace Fluentify {
         /// </summary>
         internal static string Title {
             get {
-                return ResourceManager.GetString("Title", resourceCulture);
+                return ResourceManager.GetString("Title", _resourceCulture);
             }
         }
     }

--- a/src/Fluentify/AttributeAnalyzer.cs
+++ b/src/Fluentify/AttributeAnalyzer.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 public abstract class AttributeAnalyzer
     : Analyzer<AttributeSyntax>
 {
-    private readonly string name;
+    private readonly string _name;
 
     /// <summary>
     /// Facilitates construction of an analyzer that matches for the specified <paramref name="kind"/>.
@@ -23,7 +23,7 @@ public abstract class AttributeAnalyzer
     private protected AttributeAnalyzer(string name)
         : base(SyntaxKind.Attribute)
     {
-        this.name = name;
+        _name = name;
     }
 
     /// <summary>
@@ -94,6 +94,6 @@ public abstract class AttributeAnalyzer
     private bool IsAttribute(IMethodSymbol symbol)
     {
         return symbol.ContainingType is not null
-            && symbol.ContainingType.IsAttribute(name);
+            && symbol.ContainingType.IsAttribute(_name);
     }
 }

--- a/src/Fluentify/AttributeGenerator.cs
+++ b/src/Fluentify/AttributeGenerator.cs
@@ -10,8 +10,8 @@ using Microsoft.CodeAnalysis.Text;
 public abstract class AttributeGenerator
     : IIncrementalGenerator
 {
-    private readonly string name;
-    private readonly string[] targets;
+    private readonly string _name;
+    private readonly string[] _targets;
 
     /// <summary>
     /// Serves as a template for attribute generation.
@@ -20,8 +20,8 @@ public abstract class AttributeGenerator
     /// <param name="targets">The AttributeTargets for the attribute.</param>
     private protected AttributeGenerator(string name, params string[] targets)
     {
-        this.name = name;
-        this.targets = targets;
+        _name = name;
+        _targets = targets;
     }
 
     /// <inheritdoc/>
@@ -38,7 +38,7 @@ public abstract class AttributeGenerator
                 using System;
 
                 [AttributeUsage({{GetTargets()}}, Inherited = false, AllowMultiple = false)]
-                internal sealed class {{name}}Attribute
+                internal sealed class {{_name}}Attribute
                     : Attribute
                 {
                 }
@@ -47,12 +47,12 @@ public abstract class AttributeGenerator
 
         var text = SourceText.From(source, Encoding.UTF8);
 
-        context.AddSource($"{name}Attribute.g.cs", text);
+        context.AddSource($"{_name}Attribute.g.cs", text);
     }
 
     private string GetTargets()
     {
-        IEnumerable<string> parameters = targets.Select(target => $"AttributeTargets.{target}");
+        IEnumerable<string> parameters = _targets.Select(target => $"AttributeTargets.{target}");
 
         return string.Join(" | ", parameters);
     }

--- a/src/Fluentify/ClassAnalyzer.Resources.Designer.cs
+++ b/src/Fluentify/ClassAnalyzer.Resources.Designer.cs
@@ -24,9 +24,9 @@ namespace Fluentify {
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ClassAnalyzer_Resources {
         
-        private static global::System.Resources.ResourceManager resourceMan;
-        
-        private static global::System.Globalization.CultureInfo resourceCulture;
+        private static global::System.Resources.ResourceManager _resourceMan;
+
+        private static global::System.Globalization.CultureInfo _resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal ClassAnalyzer_Resources() {
@@ -38,11 +38,11 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+                if (object.ReferenceEquals(_resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Fluentify.ClassAnalyzer.Resources", typeof(ClassAnalyzer_Resources).Assembly);
-                    resourceMan = temp;
+                    _resourceMan = temp;
                 }
-                return resourceMan;
+                return _resourceMan;
             }
         }
         
@@ -53,10 +53,10 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Globalization.CultureInfo Culture {
             get {
-                return resourceCulture;
+                return _resourceCulture;
             }
             set {
-                resourceCulture = value;
+                _resourceCulture = value;
             }
         }
         
@@ -65,7 +65,7 @@ namespace Fluentify {
         /// </summary>
         internal static string AccessibleDefaultConstructorRuleDescription {
             get {
-                return ResourceManager.GetString("AccessibleDefaultConstructorRuleDescription", resourceCulture);
+                return ResourceManager.GetString("AccessibleDefaultConstructorRuleDescription", _resourceCulture);
             }
         }
         
@@ -74,7 +74,7 @@ namespace Fluentify {
         /// </summary>
         internal static string AccessibleDefaultConstructorRuleMessageFormat {
             get {
-                return ResourceManager.GetString("AccessibleDefaultConstructorRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("AccessibleDefaultConstructorRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -83,7 +83,7 @@ namespace Fluentify {
         /// </summary>
         internal static string AccessibleDefaultConstructorRuleTitle {
             get {
-                return ResourceManager.GetString("AccessibleDefaultConstructorRuleTitle", resourceCulture);
+                return ResourceManager.GetString("AccessibleDefaultConstructorRuleTitle", _resourceCulture);
             }
         }
     }

--- a/src/Fluentify/DescriptorAttributeAnalyzer.Resources.Designer.cs
+++ b/src/Fluentify/DescriptorAttributeAnalyzer.Resources.Designer.cs
@@ -24,9 +24,9 @@ namespace Fluentify {
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DescriptorAttributeAnalyzer_Resources {
         
-        private static global::System.Resources.ResourceManager resourceMan;
-        
-        private static global::System.Globalization.CultureInfo resourceCulture;
+        private static global::System.Resources.ResourceManager _resourceMan;
+
+        private static global::System.Globalization.CultureInfo _resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal DescriptorAttributeAnalyzer_Resources() {
@@ -38,11 +38,11 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+                if (object.ReferenceEquals(_resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Fluentify.DescriptorAttributeAnalyzer.Resources", typeof(DescriptorAttributeAnalyzer_Resources).Assembly);
-                    resourceMan = temp;
+                    _resourceMan = temp;
                 }
-                return resourceMan;
+                return _resourceMan;
             }
         }
         
@@ -53,10 +53,10 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Globalization.CultureInfo Culture {
             get {
-                return resourceCulture;
+                return _resourceCulture;
             }
             set {
-                resourceCulture = value;
+                _resourceCulture = value;
             }
         }
         
@@ -65,7 +65,7 @@ namespace Fluentify {
         /// </summary>
         internal static string DisregardedRuleDescription {
             get {
-                return ResourceManager.GetString("DisregardedRuleDescription", resourceCulture);
+                return ResourceManager.GetString("DisregardedRuleDescription", _resourceCulture);
             }
         }
         
@@ -74,7 +74,7 @@ namespace Fluentify {
         /// </summary>
         internal static string DisregardedRuleMessageFormat {
             get {
-                return ResourceManager.GetString("DisregardedRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("DisregardedRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -83,7 +83,7 @@ namespace Fluentify {
         /// </summary>
         internal static string DisregardedRuleTitle {
             get {
-                return ResourceManager.GetString("DisregardedRuleTitle", resourceCulture);
+                return ResourceManager.GetString("DisregardedRuleTitle", _resourceCulture);
             }
         }
         
@@ -92,7 +92,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MissingFluentifyRuleDescription {
             get {
-                return ResourceManager.GetString("MissingFluentifyRuleDescription", resourceCulture);
+                return ResourceManager.GetString("MissingFluentifyRuleDescription", _resourceCulture);
             }
         }
         
@@ -101,7 +101,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MissingFluentifyRuleMessageFormat {
             get {
-                return ResourceManager.GetString("MissingFluentifyRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("MissingFluentifyRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -110,7 +110,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MissingFluentifyRuleTitle {
             get {
-                return ResourceManager.GetString("MissingFluentifyRuleTitle", resourceCulture);
+                return ResourceManager.GetString("MissingFluentifyRuleTitle", _resourceCulture);
             }
         }
         
@@ -119,7 +119,7 @@ namespace Fluentify {
         /// </summary>
         internal static string RedundantRuleDescription {
             get {
-                return ResourceManager.GetString("RedundantRuleDescription", resourceCulture);
+                return ResourceManager.GetString("RedundantRuleDescription", _resourceCulture);
             }
         }
         
@@ -128,7 +128,7 @@ namespace Fluentify {
         /// </summary>
         internal static string RedundantRuleMessageFormat {
             get {
-                return ResourceManager.GetString("RedundantRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("RedundantRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -137,7 +137,7 @@ namespace Fluentify {
         /// </summary>
         internal static string RedundantRuleTitle {
             get {
-                return ResourceManager.GetString("RedundantRuleTitle", resourceCulture);
+                return ResourceManager.GetString("RedundantRuleTitle", _resourceCulture);
             }
         }
         
@@ -146,7 +146,7 @@ namespace Fluentify {
         /// </summary>
         internal static string ValidNamingRuleDescription {
             get {
-                return ResourceManager.GetString("ValidNamingRuleDescription", resourceCulture);
+                return ResourceManager.GetString("ValidNamingRuleDescription", _resourceCulture);
             }
         }
         
@@ -155,7 +155,7 @@ namespace Fluentify {
         /// </summary>
         internal static string ValidNamingRuleMessageFormat {
             get {
-                return ResourceManager.GetString("ValidNamingRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("ValidNamingRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -164,7 +164,7 @@ namespace Fluentify {
         /// </summary>
         internal static string ValidNamingRuleTitle {
             get {
-                return ResourceManager.GetString("ValidNamingRuleTitle", resourceCulture);
+                return ResourceManager.GetString("ValidNamingRuleTitle", _resourceCulture);
             }
         }
     }

--- a/src/Fluentify/IgnoreAttributeAnalyzer.Resources.Designer.cs
+++ b/src/Fluentify/IgnoreAttributeAnalyzer.Resources.Designer.cs
@@ -24,9 +24,9 @@ namespace Fluentify {
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class IgnoreAttributeAnalyzer_Resources {
         
-        private static global::System.Resources.ResourceManager resourceMan;
-        
-        private static global::System.Globalization.CultureInfo resourceCulture;
+        private static global::System.Resources.ResourceManager _resourceMan;
+
+        private static global::System.Globalization.CultureInfo _resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal IgnoreAttributeAnalyzer_Resources() {
@@ -38,11 +38,11 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+                if (object.ReferenceEquals(_resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Fluentify.IgnoreAttributeAnalyzer.Resources", typeof(IgnoreAttributeAnalyzer_Resources).Assembly);
-                    resourceMan = temp;
+                    _resourceMan = temp;
                 }
-                return resourceMan;
+                return _resourceMan;
             }
         }
         
@@ -53,10 +53,10 @@ namespace Fluentify {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Globalization.CultureInfo Culture {
             get {
-                return resourceCulture;
+                return _resourceCulture;
             }
             set {
-                resourceCulture = value;
+                _resourceCulture = value;
             }
         }
         
@@ -65,7 +65,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MissingFluentifyRuleDescription {
             get {
-                return ResourceManager.GetString("MissingFluentifyRuleDescription", resourceCulture);
+                return ResourceManager.GetString("MissingFluentifyRuleDescription", _resourceCulture);
             }
         }
         
@@ -74,7 +74,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MissingFluentifyRuleMessageFormat {
             get {
-                return ResourceManager.GetString("MissingFluentifyRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("MissingFluentifyRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -83,7 +83,7 @@ namespace Fluentify {
         /// </summary>
         internal static string MissingFluentifyRuleTitle {
             get {
-                return ResourceManager.GetString("MissingFluentifyRuleTitle", resourceCulture);
+                return ResourceManager.GetString("MissingFluentifyRuleTitle", _resourceCulture);
             }
         }
         
@@ -92,7 +92,7 @@ namespace Fluentify {
         /// </summary>
         internal static string RedundantUsageRuleDescription {
             get {
-                return ResourceManager.GetString("RedundantUsageRuleDescription", resourceCulture);
+                return ResourceManager.GetString("RedundantUsageRuleDescription", _resourceCulture);
             }
         }
         
@@ -101,7 +101,7 @@ namespace Fluentify {
         /// </summary>
         internal static string RedundantUsageRuleMessageFormat {
             get {
-                return ResourceManager.GetString("RedundantUsageRuleMessageFormat", resourceCulture);
+                return ResourceManager.GetString("RedundantUsageRuleMessageFormat", _resourceCulture);
             }
         }
         
@@ -110,7 +110,7 @@ namespace Fluentify {
         /// </summary>
         internal static string RedundantUsageRuleTitle {
             get {
-                return ResourceManager.GetString("RedundantUsageRuleTitle", resourceCulture);
+                return ResourceManager.GetString("RedundantUsageRuleTitle", _resourceCulture);
             }
         }
     }

--- a/src/Fluentify/Semantics/IPropertySymbolExtensions.GetKind.cs
+++ b/src/Fluentify/Semantics/IPropertySymbolExtensions.GetKind.cs
@@ -13,7 +13,7 @@ internal static partial class IPropertySymbolExtensions
     private const string ReadOnlyCollection = "global::System.Collections.Generic.IReadOnlyCollection<T>";
     private const string ReadOnlyList = "global::System.Collections.Generic.IReadOnlyList<T>";
 
-    private static readonly IsMatch[] strategies =
+    private static readonly IsMatch[] _strategies =
     [
         IsArray,
         IsCollection,
@@ -43,7 +43,7 @@ internal static partial class IPropertySymbolExtensions
 
         kind.Type.IsBuildable = property.Type.IsBuildable(compilation, cancellationToken);
 
-        _ = Array.Exists(strategies, strategy => strategy(compilation, kind, property, cancellationToken));
+        _ = Array.Exists(_strategies, strategy => strategy(compilation, kind, property, cancellationToken));
 
         return kind;
     }


### PR DESCRIPTION
## Summary
- enforce `_`-prefixed private fields via naming rules
- update analyzers to ignore conflicting style checks
- rename existing fields across source and tests to match convention

## Testing
- `dotnet test` *(fails: Valuify package not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0e28c28c48323a0f12ca583d7b8c5