### PR TITLE
Fix delegate+instance property extension to reuse the provided instance

### DIFF
--- a/src/Fluentify.Tests/Snippets/Classes.CrossReferenced.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.CrossReferenced.cs
@@ -93,9 +93,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithSimple(instance)
-                        .WithSimple(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithSimple(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.CrossReferenced WithSimple(

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnIgnored.cs
@@ -111,9 +111,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.DescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnOptional.cs
@@ -116,9 +116,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .AttributedWith(instance)
-                        .AttributedWith(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.AttributedWith(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.DescriptorOnOptional AttributedWith(

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnRequired.cs
@@ -116,9 +116,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
         
                 public static global::Fluentify.Classes.Testing.DescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Global.cs
@@ -108,9 +108,11 @@ public static partial class Classes
             {
                 subject.ThrowIfNull("subject");
 
-                return subject
-                    .WithAttributes(instance)
-                    .WithAttributes(builder);
+                builder.ThrowIfNull("builder");
+
+                instance = builder(instance);
+
+                return subject.WithAttributes(instance);
             }
 
             public static global::Global WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.InvalidDescriptor.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.InvalidDescriptor.cs
@@ -118,9 +118,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
         
                 public static global::Fluentify.Classes.Testing.InvalidDescriptor WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.MultipleGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.MultipleGenerics.cs
@@ -70,9 +70,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAge(instance)
-                        .WithAge(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAge(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.MultipleGenerics<T1, T2, T3> WithAge<T1, T2, T3>(
@@ -145,9 +147,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.MultipleGenerics<T1, T2, T3> WithAttributes<T1, T2, T3>(
@@ -225,9 +229,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithName(instance)
-                        .WithName(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithName(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.MultipleGenerics<T1, T2, T3> WithName<T1, T2, T3>(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInClass.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInClass.cs
@@ -118,9 +118,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter.NestedInClass WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInClassWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInClassWithGenerics.cs
@@ -126,9 +126,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInStruct.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInStruct.cs
@@ -118,9 +118,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter.NestedInStruct WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInStructWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInStructWithGenerics.cs
@@ -126,9 +126,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Classes.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.OneOfThreeIgnored.cs
@@ -111,9 +111,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.OneOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnIgnored.cs
@@ -111,9 +111,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnOptional.cs
@@ -116,9 +116,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .Attributes(instance)
-                        .Attributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.Attributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnOptional Attributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnRequired.cs
@@ -117,9 +117,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Simple.cs
@@ -115,9 +115,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.Simple WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SingleGeneric.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SingleGeneric.cs
@@ -106,9 +106,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.SingleGeneric<T> WithAttributes<T>(

--- a/src/Fluentify.Tests/Snippets/Classes.SkipAutoInitializationOnProperty.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SkipAutoInitializationOnProperty.cs
@@ -99,9 +99,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithDependency(instance)
-                        .WithDependency(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithDependency(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.SkipAutoInitializationOnProperty WithDependency(

--- a/src/Fluentify.Tests/Snippets/Classes.SkipAutoInitializationOnType.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SkipAutoInitializationOnType.cs
@@ -99,9 +99,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithDependency(instance)
-                        .WithDependency(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithDependency(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.SkipAutoInitializationOnType WithDependency(

--- a/src/Fluentify.Tests/Snippets/Classes.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.TwoOfThreeIgnored.cs
@@ -68,9 +68,11 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Classes.Testing.TwoOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.CrossReferenced.cs
+++ b/src/Fluentify.Tests/Snippets/Records.CrossReferenced.cs
@@ -106,9 +106,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithSimple(instance)
-                        .WithSimple(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithSimple(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.CrossReferenced WithSimple(

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
@@ -120,9 +120,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.DescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
@@ -125,9 +125,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .AttributedWith(instance)
-                        .AttributedWith(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.AttributedWith(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.DescriptorOnOptional AttributedWith(

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
@@ -125,9 +125,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.DescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Global.cs
@@ -115,9 +115,11 @@ public static partial class Records
             {
                 subject.ThrowIfNull("subject");
 
-                return subject
-                    .WithAttributes(instance)
-                    .WithAttributes(builder);
+                builder.ThrowIfNull("builder");
+
+                instance = builder(instance);
+
+                return subject.WithAttributes(instance);
             }
 
             public static global::Global WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.InvalidDescriptor.cs
+++ b/src/Fluentify.Tests/Snippets/Records.InvalidDescriptor.cs
@@ -128,9 +128,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.InvalidDescriptor WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.MultipleGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.MultipleGenerics.cs
@@ -88,9 +88,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAge(instance)
-                        .WithAge(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAge(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.MultipleGenerics<T1, T2, T3> WithAge<T1, T2, T3>(
@@ -155,9 +157,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.MultipleGenerics<T1, T2, T3> WithAttributes<T1, T2, T3>(
@@ -227,9 +231,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithName(instance)
-                        .WithName(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithName(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.MultipleGenerics<T1, T2, T3> WithName<T1, T2, T3>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInClass.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInClass.cs
@@ -131,9 +131,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInClass WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInClassWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInClassWithGenerics.cs
@@ -139,9 +139,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInInterface.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInInterface.cs
@@ -131,9 +131,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInInterface WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInInterfaceWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInInterfaceWithGenerics.cs
@@ -139,9 +139,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInInterfaceWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInRecord.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInRecord.cs
@@ -131,9 +131,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInRecord WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInRecordWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInRecordWithGenerics.cs
@@ -139,9 +139,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInRecordWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInStruct.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInStruct.cs
@@ -131,9 +131,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInStruct WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInStructWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInStructWithGenerics.cs
@@ -139,9 +139,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
@@ -120,9 +120,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.OneOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnIgnored.cs
@@ -120,9 +120,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnOptional.cs
@@ -125,9 +125,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .Attributes(instance)
-                        .Attributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.Attributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnOptional Attributes(

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnRequired.cs
@@ -128,9 +128,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Simple.cs
@@ -125,9 +125,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.Simple WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SimpleWithDefaultConstructor.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SimpleWithDefaultConstructor.cs
@@ -106,9 +106,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SimpleWithDefaultConstructor WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SimpleWithoutPartial.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SimpleWithoutPartial.cs
@@ -92,9 +92,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SimpleWithoutPartial WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SingleGeneric.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SingleGeneric.cs
@@ -116,9 +116,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SingleGeneric<T> WithAttributes<T>(

--- a/src/Fluentify.Tests/Snippets/Records.SkipAutoInitializationOnProperty.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SkipAutoInitializationOnProperty.cs
@@ -116,9 +116,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithDependency(instance)
-                        .WithDependency(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithDependency(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SkipAutoInitializationOnProperty WithDependency(

--- a/src/Fluentify.Tests/Snippets/Records.SkipAutoInitializationOnType.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SkipAutoInitializationOnType.cs
@@ -117,9 +117,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithDependency(instance)
-                        .WithDependency(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithDependency(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.SkipAutoInitializationOnType WithDependency(

--- a/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
@@ -84,9 +84,11 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(instance)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithAttributes(instance);
                 }
 
                 public static global::Fluentify.Records.Testing.TwoOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenArray.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenArray.cs
@@ -109,9 +109,11 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(instance)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithTestProperty(instance);
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenCollection.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenCollection.cs
@@ -114,9 +114,11 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(instance)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithTestProperty(instance);
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenEnumerable.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenEnumerable.cs
@@ -97,9 +97,11 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(instance)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithTestProperty(instance);
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.cs
@@ -72,9 +72,11 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(instance)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithTestProperty(instance);
                 }
 
                 public static global::TestSubject WithTestProperty(
@@ -302,9 +304,11 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(instance)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    instance = builder(instance);
+
+                    return subject.WithTestProperty(instance);
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify/Source/PropertyExtensions.GetDelegateAndInstanceExtensionMethodBody.cs
+++ b/src/Fluentify/Source/PropertyExtensions.GetDelegateAndInstanceExtensionMethodBody.cs
@@ -20,9 +20,11 @@ internal static partial class PropertyExtensions
         }
 
         return $$"""
-            return subject
-                .{{property.Descriptor}}(instance)
-                .{{property.Descriptor}}(builder);
+            builder.ThrowIfNull("builder");
+
+            instance = builder(instance);
+
+            return subject.{{property.Descriptor}}(instance);
             """;
     }
 }


### PR DESCRIPTION
### Motivation
- The delegate+instance overload for generated property extensions previously chained to the builder-only overload, which caused array/collection scenarios to create a new instance instead of using the instance passed in the previous step.
- The change ensures the provided `instance` is mutated by the `builder` and then re-used when adding to the subject to avoid creating duplicate/new elements for array/collection properties.

### Description
- Updated the source-generator logic in `PropertyExtensions.GetDelegateAndInstanceExtensionMethodBody` to validate `builder`, invoke `instance = builder(instance)`, and return `subject.{Descriptor}(instance)` instead of chaining to the builder-only overload.
- Updated unit-test expectations in `src/Fluentify.Tests/Source/PropertyExtensionsTests/*` to reflect the new generated method body for the `instance + builder` overload.
- Updated generated snippet expectations under `src/Fluentify.Tests/Snippets/*.cs` across classes and records so snippets show `builder.ThrowIfNull(...)`, `instance = builder(instance);` and `return subject.With...(instance);`.
- Committed the changes to the test snippets and test sources that assert the generated code text matches the new behavior.

### Testing
- Attempted to run the test suite with `dotnet test`, but the .NET SDK is not available in this environment and the command failed with `dotnet: command not found` so automated tests were not executed here.
- Performed automated search-and-replace updates across tests/snippets (55 replacements) to align expectations with the updated generator behavior and committed the updated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd49fd9de4832fa9111e7c451c17d1)