### PR TITLE
Apply builder per-element for delegate+values extension overloads and update generator output

### DIFF
--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnIgnored.cs
@@ -94,8 +94,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.DescriptorOnIgnored WithAttributes(
                     this global::Fluentify.Classes.Testing.DescriptorOnIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnIgnored.cs
@@ -99,9 +99,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.DescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnOptional.cs
@@ -99,8 +99,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.DescriptorOnOptional AttributedWith(
                     this global::Fluentify.Classes.Testing.DescriptorOnOptional subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnOptional.cs
@@ -104,9 +104,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .AttributedWith(values)
-                        .AttributedWith(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.AttributedWith(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.DescriptorOnOptional AttributedWith(

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnRequired.cs
@@ -99,8 +99,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.DescriptorOnRequired WithAttributes(
                     this global::Fluentify.Classes.Testing.DescriptorOnRequired subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.DescriptorOnRequired.cs
@@ -104,9 +104,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.DescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Global.cs
@@ -96,9 +96,14 @@ public static partial class Classes
             {
                 subject.ThrowIfNull("subject");
 
-                return subject
-                    .WithAttributes(values)
-                    .WithAttributes(builder);
+                builder.ThrowIfNull("builder");
+
+                foreach (var value in values)
+                {
+                    subject = subject.WithAttributes(value, builder);
+                }
+
+                return subject;
             }
 
             public static global::Global WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Global.cs
@@ -91,8 +91,8 @@ public static partial class Classes
         {
             public static global::Global WithAttributes(
                 this global::Global subject,
-                object[] values,
-                Func<object, object> builder)
+                Func<object, object> builder,
+                params object[] values)
             {
                 subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.InvalidDescriptor.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.InvalidDescriptor.cs
@@ -106,9 +106,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.InvalidDescriptor WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.InvalidDescriptor.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.InvalidDescriptor.cs
@@ -101,8 +101,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.InvalidDescriptor WithAttributes(
                     this global::Fluentify.Classes.Testing.InvalidDescriptor subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInClass.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInClass.cs
@@ -101,8 +101,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.Outter.NestedInClass WithAttributes(
                     this global::Fluentify.Classes.Testing.Outter.NestedInClass subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInClass.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInClass.cs
@@ -106,9 +106,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter.NestedInClass WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInClassWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInClassWithGenerics.cs
@@ -112,9 +112,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInClassWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInClassWithGenerics.cs
@@ -105,8 +105,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> WithAttributes<TOutter, TInner>(
                     this global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                     where TOutter : class
                     where TInner : struct
                 {

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInStruct.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInStruct.cs
@@ -101,8 +101,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.Outter.NestedInStruct WithAttributes(
                     this global::Fluentify.Classes.Testing.Outter.NestedInStruct subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInStruct.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInStruct.cs
@@ -106,9 +106,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter.NestedInStruct WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInStructWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInStructWithGenerics.cs
@@ -112,9 +112,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Classes.NestedInStructWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.NestedInStructWithGenerics.cs
@@ -105,8 +105,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> WithAttributes<TOutter, TInner>(
                     this global::Fluentify.Classes.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                     where TOutter : class
                     where TInner : struct
                 {

--- a/src/Fluentify.Tests/Snippets/Classes.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.OneOfThreeIgnored.cs
@@ -99,9 +99,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.OneOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.OneOfThreeIgnored.cs
@@ -94,8 +94,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.OneOfThreeIgnored WithAttributes(
                     this global::Fluentify.Classes.Testing.OneOfThreeIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnIgnored.cs
@@ -99,9 +99,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnIgnored.cs
@@ -94,8 +94,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnIgnored WithAttributes(
                     this global::Fluentify.Classes.Testing.SelfDescriptorOnIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnOptional.cs
@@ -99,8 +99,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnOptional Attributes(
                     this global::Fluentify.Classes.Testing.SelfDescriptorOnOptional subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnOptional.cs
@@ -104,9 +104,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .Attributes(values)
-                        .Attributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.Attributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnOptional Attributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnRequired.cs
@@ -105,9 +105,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.SelfDescriptorOnRequired.cs
@@ -100,8 +100,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.SelfDescriptorOnRequired WithAttributes(
                     this global::Fluentify.Classes.Testing.SelfDescriptorOnRequired subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Simple.cs
@@ -103,9 +103,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.Simple WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Classes.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.Simple.cs
@@ -98,8 +98,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.Simple WithAttributes(
                     this global::Fluentify.Classes.Testing.Simple subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.TwoOfThreeIgnored.cs
@@ -51,8 +51,8 @@ public static partial class Classes
             {
                 public static global::Fluentify.Classes.Testing.TwoOfThreeIgnored WithAttributes(
                     this global::Fluentify.Classes.Testing.TwoOfThreeIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Classes.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Classes.TwoOfThreeIgnored.cs
@@ -56,9 +56,14 @@ public static partial class Classes
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Classes.Testing.TwoOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
@@ -108,9 +108,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.DescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnIgnored.cs
@@ -103,8 +103,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.DescriptorOnIgnored WithAttributes(
                     this global::Fluentify.Records.Testing.DescriptorOnIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
@@ -113,9 +113,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .AttributedWith(values)
-                        .AttributedWith(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.AttributedWith(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.DescriptorOnOptional AttributedWith(

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnOptional.cs
@@ -108,8 +108,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.DescriptorOnOptional AttributedWith(
                     this global::Fluentify.Records.Testing.DescriptorOnOptional subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
@@ -108,8 +108,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.DescriptorOnRequired WithAttributes(
                     this global::Fluentify.Records.Testing.DescriptorOnRequired subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.DescriptorOnRequired.cs
@@ -113,9 +113,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.DescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Global.cs
@@ -98,8 +98,8 @@ public static partial class Records
         {
             public static global::Global WithAttributes(
                 this global::Global subject,
-                object[] values,
-                Func<object, object> builder)
+                Func<object, object> builder,
+                params object[] values)
             {
                 subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.Global.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Global.cs
@@ -103,9 +103,14 @@ public static partial class Records
             {
                 subject.ThrowIfNull("subject");
 
-                return subject
-                    .WithAttributes(values)
-                    .WithAttributes(builder);
+                builder.ThrowIfNull("builder");
+
+                foreach (var value in values)
+                {
+                    subject = subject.WithAttributes(value, builder);
+                }
+
+                return subject;
             }
 
             public static global::Global WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.InvalidDescriptor.cs
+++ b/src/Fluentify.Tests/Snippets/Records.InvalidDescriptor.cs
@@ -116,9 +116,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.InvalidDescriptor WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.InvalidDescriptor.cs
+++ b/src/Fluentify.Tests/Snippets/Records.InvalidDescriptor.cs
@@ -111,8 +111,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.InvalidDescriptor WithAttributes(
                     this global::Fluentify.Records.Testing.InvalidDescriptor subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.NestedInClass.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInClass.cs
@@ -119,9 +119,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInClass WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInClass.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInClass.cs
@@ -114,8 +114,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter.NestedInClass WithAttributes(
                     this global::Fluentify.Records.Testing.Outter.NestedInClass subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.NestedInClassWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInClassWithGenerics.cs
@@ -118,8 +118,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> WithAttributes<TOutter, TInner>(
                     this global::Fluentify.Records.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                     where TOutter : class
                     where TInner : struct
                 {

--- a/src/Fluentify.Tests/Snippets/Records.NestedInClassWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInClassWithGenerics.cs
@@ -125,9 +125,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInClassWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInInterface.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInInterface.cs
@@ -119,9 +119,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInInterface WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInInterface.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInInterface.cs
@@ -114,8 +114,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter.NestedInInterface WithAttributes(
                     this global::Fluentify.Records.Testing.Outter.NestedInInterface subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.NestedInInterfaceWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInInterfaceWithGenerics.cs
@@ -118,8 +118,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInInterfaceWithGenerics<TInner> WithAttributes<TOutter, TInner>(
                     this global::Fluentify.Records.Testing.Outter<TOutter>.NestedInInterfaceWithGenerics<TInner> subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                     where TOutter : class
                     where TInner : struct
                 {

--- a/src/Fluentify.Tests/Snippets/Records.NestedInInterfaceWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInInterfaceWithGenerics.cs
@@ -125,9 +125,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInInterfaceWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInRecord.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInRecord.cs
@@ -114,8 +114,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter.NestedInRecord WithAttributes(
                     this global::Fluentify.Records.Testing.Outter.NestedInRecord subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.NestedInRecord.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInRecord.cs
@@ -119,9 +119,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInRecord WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInRecordWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInRecordWithGenerics.cs
@@ -125,9 +125,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInRecordWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInRecordWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInRecordWithGenerics.cs
@@ -118,8 +118,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInRecordWithGenerics<TInner> WithAttributes<TOutter, TInner>(
                     this global::Fluentify.Records.Testing.Outter<TOutter>.NestedInRecordWithGenerics<TInner> subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                     where TOutter : class
                     where TInner : struct
                 {

--- a/src/Fluentify.Tests/Snippets/Records.NestedInStruct.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInStruct.cs
@@ -114,8 +114,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter.NestedInStruct WithAttributes(
                     this global::Fluentify.Records.Testing.Outter.NestedInStruct subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.NestedInStruct.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInStruct.cs
@@ -119,9 +119,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter.NestedInStruct WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.NestedInStructWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInStructWithGenerics.cs
@@ -118,8 +118,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> WithAttributes<TOutter, TInner>(
                     this global::Fluentify.Records.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                     where TOutter : class
                     where TInner : struct
                 {

--- a/src/Fluentify.Tests/Snippets/Records.NestedInStructWithGenerics.cs
+++ b/src/Fluentify.Tests/Snippets/Records.NestedInStructWithGenerics.cs
@@ -125,9 +125,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Outter<TOutter>.NestedInStructWithGenerics<TInner> WithAttributes<TOutter, TInner>(

--- a/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
@@ -108,9 +108,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.OneOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.OneOfThreeIgnored.cs
@@ -103,8 +103,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.OneOfThreeIgnored WithAttributes(
                     this global::Fluentify.Records.Testing.OneOfThreeIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnIgnored.cs
@@ -108,9 +108,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnIgnored.cs
@@ -103,8 +103,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnIgnored WithAttributes(
                     this global::Fluentify.Records.Testing.SelfDescriptorOnIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnOptional.cs
@@ -113,9 +113,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .Attributes(values)
-                        .Attributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.Attributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnOptional Attributes(

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnOptional.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnOptional.cs
@@ -108,8 +108,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnOptional Attributes(
                     this global::Fluentify.Records.Testing.SelfDescriptorOnOptional subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnRequired.cs
@@ -111,8 +111,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnRequired WithAttributes(
                     this global::Fluentify.Records.Testing.SelfDescriptorOnRequired subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnRequired.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SelfDescriptorOnRequired.cs
@@ -116,9 +116,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.SelfDescriptorOnRequired WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Simple.cs
@@ -113,9 +113,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.Simple WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.Simple.cs
+++ b/src/Fluentify.Tests/Snippets/Records.Simple.cs
@@ -108,8 +108,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.Simple WithAttributes(
                     this global::Fluentify.Records.Testing.Simple subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.SimpleWithDefaultConstructor.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SimpleWithDefaultConstructor.cs
@@ -94,9 +94,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.SimpleWithDefaultConstructor WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SimpleWithDefaultConstructor.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SimpleWithDefaultConstructor.cs
@@ -89,8 +89,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.SimpleWithDefaultConstructor WithAttributes(
                     this global::Fluentify.Records.Testing.SimpleWithDefaultConstructor subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.SimpleWithoutPartial.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SimpleWithoutPartial.cs
@@ -80,9 +80,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.SimpleWithoutPartial WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.SimpleWithoutPartial.cs
+++ b/src/Fluentify.Tests/Snippets/Records.SimpleWithoutPartial.cs
@@ -75,8 +75,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.SimpleWithoutPartial WithAttributes(
                     this global::Fluentify.Records.Testing.SimpleWithoutPartial subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
@@ -72,9 +72,14 @@ public static partial class Records
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithAttributes(values)
-                        .WithAttributes(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithAttributes(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::Fluentify.Records.Testing.TwoOfThreeIgnored WithAttributes(

--- a/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
+++ b/src/Fluentify.Tests/Snippets/Records.TwoOfThreeIgnored.cs
@@ -67,8 +67,8 @@ public static partial class Records
             {
                 public static global::Fluentify.Records.Testing.TwoOfThreeIgnored WithAttributes(
                     this global::Fluentify.Records.Testing.TwoOfThreeIgnored subject,
-                    object[] values,
-                    Func<object, object> builder)
+                    Func<object, object> builder,
+                    params object[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenArray.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenArray.cs
@@ -92,8 +92,8 @@ public sealed partial class WhenGetExtensionsIsCalled
 
                 public static global::TestSubject WithTestProperty(
                     this global::TestSubject subject,
-                    TestType[] values,
-                    Func<TestType, TestType> builder)
+                    Func<TestType, TestType> builder,
+                    params TestType[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenArray.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenArray.cs
@@ -97,9 +97,14 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(values)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithTestProperty(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenCollection.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenCollection.cs
@@ -97,8 +97,8 @@ public sealed partial class WhenGetExtensionsIsCalled
 
                 public static global::TestSubject WithTestProperty(
                     this global::TestSubject subject,
-                    TestType[] values,
-                    Func<TestType, TestType> builder)
+                    Func<TestType, TestType> builder,
+                    params TestType[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenCollection.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenCollection.cs
@@ -102,9 +102,14 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(values)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithTestProperty(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenEnumerable.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenEnumerable.cs
@@ -80,8 +80,8 @@ public sealed partial class WhenGetExtensionsIsCalled
             {
                 public static global::TestSubject WithTestProperty(
                     this global::TestSubject subject,
-                    TestType[] values,
-                    Func<TestType, TestType> builder)
+                    Func<TestType, TestType> builder,
+                    params TestType[] values)
                 {
                     subject.ThrowIfNull("subject");
 

--- a/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenEnumerable.cs
+++ b/src/Fluentify.Tests/Source/PropertyExtensionsTests/WhenGetExtensionsIsCalled.WhenEnumerable.cs
@@ -85,9 +85,14 @@ public sealed partial class WhenGetExtensionsIsCalled
                 {
                     subject.ThrowIfNull("subject");
 
-                    return subject
-                        .WithTestProperty(values)
-                        .WithTestProperty(builder);
+                    builder.ThrowIfNull("builder");
+
+                    foreach (var value in values)
+                    {
+                        subject = subject.WithTestProperty(value, builder);
+                    }
+
+                    return subject;
                 }
 
                 public static global::TestSubject WithTestProperty(

--- a/src/Fluentify/Source/PropertyExtensions.GetDelegateAndValuesExtensionMethodBody.cs
+++ b/src/Fluentify/Source/PropertyExtensions.GetDelegateAndValuesExtensionMethodBody.cs
@@ -15,9 +15,14 @@ internal static partial class PropertyExtensions
         }
 
         return $$"""
-            return subject
-                .{{property.Descriptor}}(values)
-                .{{property.Descriptor}}(builder);
+            builder.ThrowIfNull("builder");
+
+            foreach (var value in values)
+            {
+                subject = subject.{{property.Descriptor}}(value, builder);
+            }
+
+            return subject;
             """;
     }
 }

--- a/src/Fluentify/Source/PropertyExtensions.GetExtensions.cs
+++ b/src/Fluentify/Source/PropertyExtensions.GetExtensions.cs
@@ -59,7 +59,7 @@ internal static partial class PropertyExtensions
         [
             (property.GetArrayExtensionMethodBody(scalar), $"params {member}[] values"),
             (property.GetCollectionExtensionMethodBody(scalar), $"params {member}[] values"),
-            (property.GetDelegateAndValuesExtensionMethodBody(type), $"{type.Name}[] values,\r\n    Func<{type.Name}, {type.Name}> builder"),
+            (property.GetDelegateAndValuesExtensionMethodBody(type), $"Func<{type.Name}, {type.Name}> builder,\r\n    params {type.Name}[] values"),
             (property.GetDelegateAndInstanceExtensionMethodBody(type), $"{type.Name} instance,\r\n    Func<{type.Name}, {type.Name}> builder"),
             (property.GetDelegateExtensionMethodBody(type), $"Func<{type.Name}, {type.Name}> builder"),
             (property.GetEnumerableExtensionMethodBody(scalar), $"params {member}[] values"),


### PR DESCRIPTION
### Motivation
- The code generator emitted extension overloads that chained `With*(values)` and `With*(builder)`, which did not apply the `builder` to each element and produced incorrect semantics for delegate+values overloads.

### Description
- Update `PropertyExtensions.GetDelegateAndValuesExtensionMethodBody` to `ThrowIfNull` on `builder`, iterate `values`, and call the single-item overload via `subject = subject.{{property.Descriptor}}(value, builder)` before returning `subject`.
- Regenerate and update many generated snippet files (classes and records) so the extension methods now validate the `builder` and loop over `values` to apply the builder per element.
- Modify tests/snippets for array/collection/enumerable property cases to reflect the new per-element builder application.

### Testing
- Ran the automated test suite with `dotnet test`, including snapshot/golden-file checks for generated snippets, and the tests completed successfully.
- Verified updated snippet files are consistent with the new generator output via the test-run snapshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd52809748832f8d859bd75ad4e38c)