### PR TITLE
Exclude non-generic-only collection types from builder extension generation (breaking fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- Builder extensions are no longer generated for properties whose type only exposes non-generic collection interfaces such as `ICollection`, `IEnumerable`, or `IList`, because Fluentify cannot infer the intended element type. **Breaking Change**
 - Extensions for collection properties now throw `ArgumentNullException` when a `null` value is passed opposed to `NullReferenceException`.
 
 # [2.3.1] - 2026-05-31

--- a/src/Fluentify.Tests/Semantics/IPropertySymbolExtensionsTests/WhenGetKindIsCalled.cs
+++ b/src/Fluentify.Tests/Semantics/IPropertySymbolExtensionsTests/WhenGetKindIsCalled.cs
@@ -56,7 +56,7 @@ public sealed class WhenGetKindIsCalled
     }
 
     [Fact]
-    public void GivenNonGenericCollectionPropertyThenKindIsEnumerable()
+    public void GivenNonGenericCollectionPropertyThenKindIsScalar()
     {
         // Arrange
         IPropertySymbol property = GetProperty("NonGenericCollectionItems");
@@ -65,12 +65,26 @@ public sealed class WhenGetKindIsCalled
         Kind kind = property.GetKind(_compilation, CancellationToken.None);
 
         // Assert
-        kind.Pattern.ShouldBe(Pattern.Enumerable);
-        kind.Member.Name.ShouldBe("object");
+        kind.Pattern.ShouldBe(Pattern.Scalar);
+        kind.Type.IsFrameworkType.ShouldBeTrue();
     }
 
     [Fact]
-    public void GivenNonGenericListPropertyThenKindIsEnumerable()
+    public void GivenNonGenericEnumerablePropertyThenKindIsScalar()
+    {
+        // Arrange
+        IPropertySymbol property = GetProperty("NonGenericEnumerableItems");
+
+        // Act
+        Kind kind = property.GetKind(_compilation, CancellationToken.None);
+
+        // Assert
+        kind.Pattern.ShouldBe(Pattern.Scalar);
+        kind.Type.IsFrameworkType.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenNonGenericListPropertyThenKindIsScalar()
     {
         // Arrange
         IPropertySymbol property = GetProperty("NonGenericListItems");
@@ -79,8 +93,23 @@ public sealed class WhenGetKindIsCalled
         Kind kind = property.GetKind(_compilation, CancellationToken.None);
 
         // Assert
-        kind.Pattern.ShouldBe(Pattern.Enumerable);
-        kind.Member.Name.ShouldBe("object");
+        kind.Pattern.ShouldBe(Pattern.Scalar);
+        kind.Type.IsFrameworkType.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenOnlyNonGenericCollectionImplementationThenKindIsScalar()
+    {
+        // Arrange
+        IPropertySymbol property = GetProperty("NonGenericOnlyItems");
+
+        // Act
+        Kind kind = property.GetKind(_compilation, CancellationToken.None);
+
+        // Assert
+        kind.Pattern.ShouldBe(Pattern.Scalar);
+        kind.Type.IsBuildable.ShouldBeFalse();
+        kind.Type.IsFrameworkType.ShouldBeTrue();
     }
 
     [Fact]
@@ -161,6 +190,7 @@ public sealed class WhenGetKindIsCalled
 
             namespace Demo
             {
+                using System;
                 using System.Collections;
                 using System.Collections.Generic;
                 using System.Collections.Immutable;
@@ -179,6 +209,24 @@ public sealed class WhenGetKindIsCalled
                     }
                 }
 
+                public sealed class NonGenericOnlyCollection : ICollection
+                {
+                    public int Count => 0;
+
+                    public bool IsSynchronized => false;
+
+                    public object SyncRoot => this;
+
+                    public void CopyTo(Array array, int index)
+                    {
+                    }
+
+                    public IEnumerator GetEnumerator()
+                    {
+                        yield break;
+                    }
+                }
+
                 public sealed class Sample
                 {
                     public Element[] ArrayItems { get; } = new Element[0];
@@ -191,7 +239,11 @@ public sealed class WhenGetKindIsCalled
 
                     public ICollection NonGenericCollectionItems { get; } = new ArrayList();
 
+                    public IEnumerable NonGenericEnumerableItems { get; } = new ArrayList();
+
                     public IList NonGenericListItems { get; } = new ArrayList();
+
+                    public NonGenericOnlyCollection NonGenericOnlyItems { get; } = new NonGenericOnlyCollection();
 
                     public Element? NullableElement { get; } = default;
 

--- a/src/Fluentify/Semantics/IPropertySymbolExtensions.GetKind.cs
+++ b/src/Fluentify/Semantics/IPropertySymbolExtensions.GetKind.cs
@@ -19,6 +19,7 @@ internal static partial class IPropertySymbolExtensions
     private const string ImmutableList = "global::System.Collections.Immutable.ImmutableList<T>";
     private const string ImmutableSortedSet = "global::System.Collections.Immutable.ImmutableSortedSet<T>";
     private const string NonGenericCollection = "global::System.Collections.ICollection";
+    private const string NonGenericEnumerable = "global::System.Collections.IEnumerable";
     private const string NonGenericList = "global::System.Collections.IList";
     private const int ExpectedArgumentsForCollectionType = 1;
 
@@ -65,9 +66,11 @@ internal static partial class IPropertySymbolExtensions
         string typeInitialization = initialization;
         bool hasTypeInitialization = !hasInitialization && property.Type.TryGetInitialization(out typeInitialization);
 
-        bool isBuildable = property.Type.IsBuildable(compilation, cancellationToken)
-            || hasInitialization
-            || hasTypeInitialization;
+        bool isOnlyNonGenericCollection = property.IsOnlyNonGenericCollectionType();
+        bool isBuildable = !isOnlyNonGenericCollection
+            && (property.Type.IsBuildable(compilation, cancellationToken)
+                || hasInitialization
+                || hasTypeInitialization);
 
         string effectiveInitialization = hasInitialization
             ? initialization
@@ -79,7 +82,7 @@ internal static partial class IPropertySymbolExtensions
             Type = new()
             {
                 Initialization = GetInitialization(effectiveInitialization, property.Type),
-                IsFrameworkType = property.Type.IsFrameworkType(),
+                IsFrameworkType = isOnlyNonGenericCollection || property.Type.IsFrameworkType(),
                 IsNullable = property.Type.IsNullable(),
                 IsValueType = property.Type.IsValueType(),
                 Name = property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
@@ -133,15 +136,7 @@ internal static partial class IPropertySymbolExtensions
             return true;
         }
 
-        if (!property.IsNonGenericType(NonGenericCollection, NonGenericList))
-        {
-            return false;
-        }
-
-        kind.Pattern = Pattern.Enumerable;
-        kind.Member = GetType(compilation, compilation.GetSpecialType(SpecialType.System_Object), cancellationToken);
-
-        return true;
+        return false;
     }
 
     private static Type GetType(Compilation compilation, ITypeSymbol type, CancellationToken cancellationToken)
@@ -184,6 +179,26 @@ internal static partial class IPropertySymbolExtensions
         name = type.ToDisplayString(NullableFlowState.NotNull, _fullyQualifiedNonNullable);
 
         return initializer(name);
+    }
+
+    private static bool HasGenericCollectionType(this IPropertySymbol property)
+    {
+        if (property.Type is INamedTypeSymbol type
+            && type.TypeArguments.Length == ExpectedArgumentsForCollectionType
+            && type.OriginalDefinition.IsType(_collections))
+        {
+            return true;
+        }
+
+        return property.Type.AllInterfaces
+            .Where(@interface => @interface.TypeArguments.Length == ExpectedArgumentsForCollectionType)
+            .Any(@interface => @interface.OriginalDefinition.IsType(_collections));
+    }
+
+    private static bool IsOnlyNonGenericCollectionType(this IPropertySymbol property)
+    {
+        return property.IsNonGenericType(NonGenericCollection, NonGenericEnumerable, NonGenericList)
+            && !property.HasGenericCollectionType();
     }
 
     private static bool IsType(this IPropertySymbol property, out ITypeSymbol element, params string[] names)


### PR DESCRIPTION
### Motivation

- Non-generic collection interfaces such as `ICollection`, `IEnumerable`, and `IList` do not expose an element type, so builder-based overloads must not be generated for properties that only expose those non-generic interfaces. This avoids producing incorrect `object`-typed builder overloads and prevents runtime/compile surprises for consumers.

### Description

- Updated `IPropertySymbolExtensions.GetKind` to detect properties whose type only exposes non-generic collection interfaces and to treat those types as framework-style scalar values by marking them non-buildable and framework-like (`IsOnlyNonGenericCollectionType`, `HasGenericCollectionType`).
- Removed the previous non-generic fallback that treated non-generic `ICollection/IList` as enumerable of `object`, so `IsEnumerable` now only succeeds for known generic collection shapes.
- Added helper methods `HasGenericCollectionType` and `IsOnlyNonGenericCollectionType` in `src/Fluentify/Semantics/IPropertySymbolExtensions.GetKind.cs` to encapsulate the detection logic.
- Updated semantic tests in `src/Fluentify.Tests/Semantics/IPropertySymbolExtensionsTests/WhenGetKindIsCalled.cs` to assert that non-generic `ICollection`, `IEnumerable`, `IList`, and a custom non-generic-only implementation are treated as scalar and not buildable, and recorded the change in `CHANGELOG.md` as a breaking bug fix.

### Testing

- Ran `git diff --check` to validate whitespace/format issues and fixed CRLF/trailing whitespace issues so the repository checks pass. 
- Updated unit tests were committed but `dotnet test` could not be executed in this environment because the `dotnet` SDK is not installed, so tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206713a290832f99442b965f91ad29)